### PR TITLE
Fix 404 missing favicon

### DIFF
--- a/welcome/index.html
+++ b/welcome/index.html
@@ -10,7 +10,7 @@
 				padding: 0;
 				margin: 0;
 			}
-			
+
 			body {
 				background: #f1f4f5;
 				font-family: sans-serif;
@@ -38,7 +38,7 @@
 			.paper {
 				position: relative;
 				flex-shrink: 0;
-				width: 100%;				
+				width: 100%;
 
 				background: white;
 				border-radius: 3px;
@@ -221,7 +221,7 @@
 				<p>
 					Remember, Caddy can do a lot more than serve static files. It's also a powerful reverse proxy and application platform. You can use the Caddyfile to enable any other features you need. Or you could use Caddy's API to configure it programmatically.
 				</p>
-				<p>	
+				<p>
 					Everything you need to know is either in the <a href="https://github.com/caddyserver/caddy/wiki/v2:-Documentation">📖 Caddy documentation</a> or the manual for your OS/platform. Have fun!
 				</p>
 
@@ -246,7 +246,7 @@
 					If you still need help, we have a <a href="https://caddy.community/">great community</a>! First <a href="https://caddy.community/search">try a search</a>, and if your question is original, go ahead and ask it! Remember to pay it forward and help others too. 😁
 				</p>
 				<p>
-					Visit Caddy on: 
+					Visit Caddy on:
 					<b><a href="https://github.com/caddyserver/caddy" title="Caddy on GitHub">GitHub</a></b>
 					or
 					<b><a href="https://twitter.com/caddyserver" title="@caddyserver on Twitter">Twitter</a></b>

--- a/welcome/index.html
+++ b/welcome/index.html
@@ -4,6 +4,7 @@
 		<title>Caddy works!</title>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="icon" href="data:,">
 		<style>
 			* {
 				box-sizing: border-box;


### PR DESCRIPTION
I noticed the fallowing log line:

```
2019/10/27 12:19:43 [ERROR] [GET /favicon.ico] {id=u26et3nkw} fileserver.(*FileServer).ServeHTTP (staticfiles.go:103): HTTP 404: stat /usr/share/caddy/favicon.ico: no such file or directory
```

Using a (empty) favicon placeholder it would prevent the above "error".

My editor also removed trailing whitespace. Maybe we could add a [.editorconfig](https://editorconfig.org/) file? There are plugins for all kind of editor's.