### PR TITLE
[archlinux] adjust pkgbuild + add files

### DIFF
--- a/archlinux/Caddyfile
+++ b/archlinux/Caddyfile
@@ -1,0 +1,25 @@
+# The Caddyfile is an easy way to configure your Caddy web server.
+#
+# Unless the file starts with a global options block, the first
+# uncommented line is always the address of your site.
+#
+# To use your own domain name (with automatic HTTPS), first make
+# sure your domain's A/AAAA DNS records are properly pointed to
+# this machine's public IP, then replace the line below with your
+# domain name.
+:80
+
+# Set this path to your site's directory.
+root * /usr/share/caddy
+
+# Enable the static file server.
+file_server
+
+# Another common task is to set up a reverse proxy:
+# reverse_proxy localhost:8080
+
+# Or serve a PHP site through php-fpm:
+# php_fastcgi localhost:9000
+
+# Refer to the Caddy docs for more information:
+# https://github.com/caddyserver/caddy/wiki/v2:-Documentation

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,26 +1,51 @@
 # Maintainer : Christian Rebischke <chris.rebischke@archlinux.org>
 
 pkgname=caddy
-pkgver=2.0.0beta10
-_pkgver=2.0.0-beta10
+pkgver=2.0.0beta12
+_gitcommit='3d9f8eac08e172d99eafb396f161263fd444c073'
+_distcommit='9e93bfd85c97d71ab842a4a4b555d358295c914e'
 pkgrel=1
 pkgdesc="Powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
 arch=('x86_64')
 url="https://github.com/caddyserver/caddy"
 license=('Apache')
-makedepends=('go-pie' 'git')
 depends=('glibc')
-source=("${pkgname}-${pkgver}::git+https://github.com/caddyserver/caddy#tag=v${_pkgver}?signed")
-sha512sums=('SKIP')
-validpgpkeys=('29D0817A67156E4F25DC24782A349DD577D586A5')
+makedepends=('go-pie' 'git')
+backup=('etc/caddy/Caddyfile')
+source=("git+https://github.com/caddyserver/caddy#commit=${_gitcommit}?signed"
+        "caddy-${_distcommit}-index.html::https://raw.githubusercontent.com/caddyserver/dist/${_distcommit}/welcome/index.html"
+        'caddy.service'
+        'caddy.tmpfiles'
+        'Caddyfile')
+sha512sums=('SKIP'
+            '7836722155509009cbd8eaf605e2d09a2aefd58a90e5973156ec6363aa5ba2ed6ec30a57d2ee9b4e6e4910d02243ffbed92c366b1eb2076d0da71c2d4f930175'
+            'b1ff442e9972af44ea0560e3a5b8359ec94ce2f692e85c5413ba1b0963cb53159338b578f4cac4f8c445c818de5ef8f5b8a67af2ec6cb7303c475b81028c2e24'
+            'd4a2a415a0fa75fae7aa932030d1dc33f30e964fc425aefbb4c695239ea9de9e025fe2097a6c4af35f95cf908e72db6a60615e24f1e4ad1c7d93a04793bfefb0'
+            '245b7de1e6e66642bd35e3e09b04c64323892676f671cdede6e31fabfe1b4c50692686ae14327152c8dcc4306880413450e5ab69f920e20460e01b56a52daf7d')
+validpgpkeys=(
+  '29D0817A67156E4F25DC24782A349DD577D586A5' # Matthew Holt <mholt@users.noreply.github.com>
+)
+
+pkgver() {
+  cd ${pkgname}
+  git describe --tags --match 'v*' | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+prepare() {
+  sed 's|/var/www/html|/srv/http|g' -i "${srcdir}/caddy-${_distcommit}-index.html"
+}
 
 build() {
-  cd "${pkgname}-${pkgver}/cmd/caddy/"
+  cd "${pkgname}/cmd/caddy/"
   go build -trimpath -ldflags "-extldflags ${LDFLAGS}" -o caddy
 }
 
 package() {
-  cd "${pkgname}-${pkgver}"
+  cd "${pkgname}"
   install -Dm755 "cmd/caddy/${pkgname}" "${pkgdir}/usr/bin/${pkgname}"
+  install -Dm 644 "${srcdir}/caddy.service" -t "${pkgdir}/usr/lib/systemd/system"
+  install -Dm 644 "${srcdir}/caddy.tmpfiles" "${pkgdir}/usr/lib/tmpfiles.d/caddy.conf"
+  install -Dm 644 "${srcdir}/Caddyfile" "${pkgdir}/etc/caddy/Caddyfile"
+  install -Dm 644 "${srcdir}/caddy-${_distcommit}-index.html" "${pkgdir}/usr/share/caddy/index.html"
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 }

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer : Christian Rebischke <chris.rebischke@archlinux.org>
 
 pkgname=caddy
-pkgver=2.0.0beta12
-_gitcommit='3d9f8eac08e172d99eafb396f161263fd444c073'
+pkgver=2.0.0beta13
+_gitcommit='6614d1c495f3266037d36b4c2f4f70fcc73acad1'
 _distcommit='9e93bfd85c97d71ab842a4a4b555d358295c914e'
 pkgrel=1
 pkgdesc="Powerful, enterprise-ready, open source web server with automatic HTTPS written in Go"
@@ -38,6 +38,11 @@ prepare() {
 build() {
   cd "${pkgname}/cmd/caddy/"
   go build -trimpath -ldflags "-extldflags ${LDFLAGS}" -o caddy
+}
+
+check() {
+  cd "${pkgname}"
+  go test ./...
 }
 
 package() {

--- a/archlinux/caddy.service
+++ b/archlinux/caddy.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Caddy Web Server
+Documentation=https://caddyserver.com/docs/
+After=network.target
+
+[Service]
+User=http
+Group=http
+ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile --adapter caddyfile --resume --environ
+ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+TimeoutStopSec=5s
+LimitNOFILE=1048576
+LimitNPROC=512
+
+# Hardening options
+PrivateTmp=true
+ProtectSystem=strict
+PrivateDevices=true
+ProtectHome=true
+ReadWritePaths=/var/lib/caddy /var/log/caddy
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+LockPersonality=true
+
+
+[Install]
+WantedBy=multi-user.target

--- a/archlinux/caddy.tmpfiles
+++ b/archlinux/caddy.tmpfiles
@@ -1,0 +1,2 @@
+d /var/lib/caddy 0750 http http
+d /var/log/caddy 0750 http http


### PR DESCRIPTION
We are going to ship the default caddy welcome page on Arch Linux
and we've enhanced the caddy service file with additional security
options.

Note: Arch Linux uses the 'http' user/group for web servers on default.
Therefore we've changed the caddy user/group to 'http' in our service
file.