### PR TITLE
Update caddy.service

### DIFF
--- a/init/caddy.service
+++ b/init/caddy.service
@@ -24,7 +24,8 @@ After=network.target
 [Service]
 User=caddy
 Group=caddy
-ExecStart=/usr/bin/caddy run --config /etc/caddy/Caddyfile --resume --environ
+ExecStartPre=/usr/bin/caddy adapt --config /etc/caddy/Caddyfile > .config/caddy/autosave.json
+ExecStart=/usr/bin/caddy run --resume --environ
 ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
 TimeoutStopSec=5s
 LimitNOFILE=1048576


### PR DESCRIPTION
Caddy2-Beta 20 on Debian 10: using this as the systemd service, the server really does prefer having the pre-compiled JSON to operate correctly.