### PR TITLE
packer: harden DO image with dev-sec.os-hardening

### DIFF
--- a/packer/ansible/ansible-playbook.yml
+++ b/packer/ansible/ansible-playbook.yml
@@ -1,10 +1,11 @@
 - hosts: all
   user: root
   roles:
-    # TODO (Mohammed90): customize all variables to have full control over its behavior
-    # - dev-sec.os-hardening
+    - dev-sec.os-hardening
     - dev-sec.ssh-hardening
   vars:
+    ufw_manage_defaults: false # we're managing the default ufw in scripts/10-firewall.sh
+    os_filesystem_whitelist: "vfat" # the EFI partition is formatted with this filesystem
     # Digital Ocean doesn't disable the option, regardless of whether the 
     # image supports it, so we must enable it.
     # see: https://caddy.community/t/cannot-sign-in-to-digitalocean-droplet/6963

--- a/packer/ansible/ansible-playbook.yml
+++ b/packer/ansible/ansible-playbook.yml
@@ -4,6 +4,8 @@
     - dev-sec.os-hardening
     - dev-sec.ssh-hardening
   vars:
+    sysctl_overwrite:
+      net.ipv6.conf.all.disable_ipv6: 0
     ufw_manage_defaults: false # we're managing the default ufw in scripts/10-firewall.sh
     os_filesystem_whitelist: "vfat" # the EFI partition is formatted with this filesystem
     # Digital Ocean doesn't disable the option, regardless of whether the 


### PR DESCRIPTION
The role is customized with:
- Whitelisting vfat fs
- Manually manage ufw defaults

I've collected the reported changes applied by [dev-sec.os-hardening](https://github.com/dev-sec/ansible-os-hardening). Can someone with more Linux expertise than I am please review the reported changes? FWIW, I've applied this role to my DO droplets 2+ years ago and haven't caused me any issues.

sysctl (reference: [sysctl-explorer](https://sysctl-explorer.net)):

```
changed: [default] => (item={'key': 'net.ipv4.ip_forward', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.all.forwarding', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.all.accept_ra', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.accept_ra', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.all.rp_filter', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.conf.default.rp_filter', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.icmp_echo_ignore_broadcasts', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.icmp_ignore_bogus_error_responses', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.icmp_ratelimit', 'value': 100})
changed: [default] => (item={'key': 'net.ipv4.icmp_ratemask', 'value': 88089})
changed: [default] => (item={'key': 'net.ipv6.conf.all.disable_ipv6', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.tcp_timestamps', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.all.arp_ignore', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.conf.all.arp_announce', 'value': 2})
changed: [default] => (item={'key': 'net.ipv4.tcp_rfc1337', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.conf.all.shared_media', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.conf.default.shared_media', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.conf.all.accept_source_route', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.default.accept_source_route', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.default.accept_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.all.accept_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.all.secure_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.default.secure_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.accept_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.all.accept_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.all.send_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.default.send_redirects', 'value': 0})
changed: [default] => (item={'key': 'net.ipv4.conf.all.log_martians', 'value': 1})
changed: [default] => (item={'key': 'net.ipv4.conf.default.log_martians', 'value': 1})
changed: [default] => (item={'key': 'net.ipv6.conf.default.router_solicitations', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.accept_ra_rtr_pref', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.accept_ra_pinfo', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.accept_ra_defrtr', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.autoconf', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.dad_transmits', 'value': 0})
changed: [default] => (item={'key': 'net.ipv6.conf.default.max_addresses', 'value': 1})
changed: [default] => (item={'key': 'kernel.sysrq', 'value': 0})
changed: [default] => (item={'key': 'fs.suid_dumpable', 'value': 0})
changed: [default] => (item={'key': 'kernel.randomize_va_space', 'value': 2})
changed: [default] => (item={'key': 'kernel.core_uses_pid', 'value': 1})
changed: [default] => (item={'key': 'kernel.kptr_restrict', 'value': 1})
changed: [default] => (item={'key': 'kernel.yama.ptrace_scope', 'value': 1})
changed: [default] => (item={'key': 'vm.mmap_min_addr', 'value': 65536})
changed: [default] => (item={'key': 'fs.protected_hardlinks', 'value': 1})
changed: [default] => (item={'key': 'fs.protected_symlinks', 'value': 1})
```

remove suid/sgid bit from binaries in blacklist:
```
changed: [default] => (item=/usr/lib/eject/dmcrypt-get-device)
changed: [default] => (item=/usr/lib/openssh/ssh-keysign)
```

disable unused filesystems:
```
changed: [default]
```

add pinerolo_profile.sh to profile.d:
```
changed: [default]
```

create securetty:
```
changed: [default]
```

install the package for strong password checking
```
changed: [default]
```

configure passwdqc
```
changed: [default]
```

configure passwdqc and tally via central system-auth confic
```
changed: [default]
```

NSA 2.3.3.5 Upgrade Password Hashing Algorithm to SHA-512:
```
changed: [default]
```

change su-binary to only be accessible to user and group root:
```
changed: [default]
```

install auditd package
```
[WARNING]: Updating cache and auto-installing missing dependency: python-apt
changed: [default]

TASK [dev-sec.os-hardening : configure auditd | package-08] ********************
changed: [default]
```

create limits.d-directory if it does not exist:
```
ok: [default]
```

create additional limits config file -> 10.hardcore.conf:
```
changed: [default]
```

set 10.hardcore.conf perms to 0400 and root ownership:
```
changed: [default]
```

create login.defs:
```
changed: [default]
```

create revoked_keys and set permissions to root/600:
```
changed: [default]
```

create sshd_config and set permissions to root/600:
```
changed: [default]
```

create ssh_config and set permissions to root/644
```
changed: [default]
```
