### PR TITLE
deb: Add debian pre/post-install and pre-remove scripts

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+BIN_DIR=/usr/local/bin
+debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
+
+case "$1" in
+	abort-upgrade|abort-remove|abort-deconfigure|configure)
+		;;
+	triggered)
+		if [[ "$(readlink /proc/1/exe)" != */systemd ]]; then
+			echo "ERROR: systemd not running."
+			exit 1
+		fi
+
+		systemctl daemon-reload || true
+
+		if systemctl is-enabled caddy >/dev/null; then
+			$debsystemctl restart caddy || true
+		else
+			systemctl enable caddy || true
+			$debsystemctl start caddy || true
+		fi
+		exit 0
+		;;
+	*)
+		echo "postinstall called with unknown argument \`$1'" >&2
+		exit 1
+		;;
+esac
+
+exit 0

--- a/scripts/preinstall.sh
+++ b/scripts/preinstall.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+if ! grep "^caddy:" /etc/group &>/dev/null; then
+	groupadd --system caddy
+fi
+
+if ! id caddy &>/dev/null; then
+	useradd --system \
+		--gid caddy \
+		--create-home \
+		--home-dir /var/lib/caddy \
+		--shell /usr/sbin/nologin \
+		--comment "Caddy web server" \
+		caddy
+fi

--- a/scripts/preremove.sh
+++ b/scripts/preremove.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+BIN_DIR=/usr/local/bin
+debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
+
+case "$1" in
+	remove|remove-in-favour|deconfigure|deconfigure-in-favour)
+		if systemctl is-enabled caddy >/dev/null; then
+			$debsystemctl stop caddy || exit $?
+		fi
+		;;
+
+	upgrade|failed-upgrade)
+		;;
+
+	*)
+		echo "preremove called with unknown argument \`$1'" >&2
+		exit 1
+		;;
+esac
+
+exit 0


### PR DESCRIPTION
Quick attempt at setting up .deb hook scripts. Hopefully I'm not missing anything! This is currently untested, but we need a starting point!

These will be used by our GoReleaser script when building the .deb packages on release. It'll be easier to test GoReleaser once this is merged because we pull this repo in CI.

Used as reference:
- https://github.com/caddyserver/dist/tree/master/init
- https://github.com/influxdata/telegraf/blob/master/scripts/post-install.sh
- https://github.com/jordansissel/fpm/blob/master/templates/deb/postinst_upgrade.sh.erb