### PR TITLE
deb: Add caddy user to www-data group if it exists

### DIFF
--- a/packer/scripts/20-caddy.sh
+++ b/packer/scripts/20-caddy.sh
@@ -10,6 +10,10 @@ useradd --system \
     --comment "Caddy web server" \
     caddy
 
+if getent group www-data >/dev/null; then
+    usermod -aG www-data caddy
+fi
+
 chown -R caddy:caddy /var/lib/caddy
 
 VERSION_SLUG=${CADDY_VERSION//v/}

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = configure ]; then
+if [ "$1" = "configure" ]; then
 	# Add user and group
 	if ! getent group caddy >/dev/null; then
 		groupadd --system caddy
@@ -14,6 +14,9 @@ if [ "$1" = configure ]; then
 			--shell /usr/sbin/nologin \
 			--comment "Caddy web server" \
 			caddy
+	fi
+	if getent group www-data >/dev/null; then
+		usermod -aG www-data caddy
 	fi
 fi
 


### PR DESCRIPTION
Didn't try it via a .deb yet but trying those exact commands locally:

```
$ getent group www-data
www-data:x:33:francis

$ getent group www-data >/dev/null && echo $?
0

$ sudo usermod -aG www-data caddy
[sudo] password for francis:

$ getent group www-data
www-data:x:33:francis,caddy
```

Should do what we need 👍