### PR TITLE
init: Require network-online to startup Caddy

### DIFF
--- a/init/caddy-api.service
+++ b/init/caddy-api.service
@@ -10,7 +10,8 @@
 [Unit]
 Description=Caddy
 Documentation=https://caddyserver.com/docs/
-After=network.target
+After=syslog.target network.target remote-fs.target nss-lookup.target network-online.target
+Requires=network-online.target
 
 [Service]
 User=caddy

--- a/init/caddy.service
+++ b/init/caddy.service
@@ -16,7 +16,8 @@
 [Unit]
 Description=Caddy
 Documentation=https://caddyserver.com/docs/
-After=network.target
+After=syslog.target network.target remote-fs.target nss-lookup.target network-online.target
+Requires=network-online.target
 
 [Service]
 User=caddy


### PR DESCRIPTION
@mholt was having issues with Caddy starting after rebooting his machine, seems like the problem is likely because it doesn't wait for `network-online`, i.e. the IP addresses have been assigned to interfaces.

See https://serverfault.com/a/674629

More info here: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

Also adding a few more `After` items that seem to make sense while we're at it.