### PR TITLE
Changes to point the systemd services file to /etc/default/caddy

### DIFF
--- a/init/README.md
+++ b/init/README.md
@@ -36,7 +36,7 @@ $ useradd --system \
 
 ## Choosing a service file
 
-- **`caddy.service`** - Use this one if you configure Caddy with a file (for example, the Caddyfile, or a .json file).
+- **`caddy.service`** - Use this one if you configure Caddy with a file (for example, the Caddyfile, or a .json file) that you specify in /et/default/caddy
 - **`caddy-api.service`** - Use this one if you configure Caddy solely through its API.
 
 The two files are identical except for the ExecStart and ExecReload commands.
@@ -49,7 +49,7 @@ Caddy receives all configuration through its [admin API](https://caddyserver.com
 
 Most users will use either config files and the CLI [mutually exclusively](https://caddyserver.com/docs/getting-started#api-vs-config-files) with the API because it is simpler to have only one source of truth. However, you may wish to provide Caddy an initial "bootstrapping" configuration with a config file, and use the API thereafter.
 
-**⚠️ If you provide an initial config file with the `--config` flag and then update the config using the API, you risk losing your changes if the service is restarted unless you have the `--resume` flag in your ExecStart command.**
+**⚠️ If you provide an initial config file with the `--config` flag and then update the config using the API, you risk losing your changes if the service is restarted unless you have the `--resume` flag in your ExecStart command, which you can add to the EXTRA_PARAMS in /etc/default/caddy.**
 
 Without the `--resume` flag, the `--config` flag will overwrite any last-known configuration.
 

--- a/init/caddy-defaults
+++ b/init/caddy-defaults
@@ -1,0 +1,6 @@
+#Defaults for caddy.service
+
+CONFIGFILE=/etc/caddy/Caddyfile
+
+#To add --resume, uncomment the line below:
+# EXTRA_PARAMS="--resume"

--- a/init/caddy.service
+++ b/init/caddy.service
@@ -1,6 +1,6 @@
 # caddy.service
 #
-# For using Caddy with a config file.
+# For using Caddy with a config file specified in /etc/default/caddy
 #
 # Make sure the ExecStart and ExecReload commands are correct
 # for your installation.
@@ -10,8 +10,9 @@
 # WARNING: This service does not use the --resume flag, so if you
 # use the API to make changes, they will be overwritten by the
 # Caddyfile next time the service is restarted. If you intend to
-# use Caddy's API to configure it, add the --resume flag to the
-# `caddy run` command or use the caddy-api.service file instead.
+# use Caddy's API to configure it, add the --resume flag to
+# EXTRA_PARAMS in /etc/default/caddy
+# or use the caddy-api.service file instead.
 
 [Unit]
 Description=Caddy
@@ -22,8 +23,9 @@ Requires=network-online.target
 [Service]
 User=caddy
 Group=caddy
-ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
-ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
+EnvironmentFile=/etc/default/caddy
+ExecStart=/usr/bin/caddy run --environ --config $CONFIGFILE $EXTRA_PARAMS
+ExecReload=/usr/bin/caddy reload --config $CONFIGFILE $EXTRA_PARAMS
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 LimitNPROC=512

--- a/rpm/caddy.spec
+++ b/rpm/caddy.spec
@@ -22,6 +22,7 @@ Source0:        https://raw.githubusercontent.com/caddyserver/caddy/%{tag}/cmd/c
 # https://github.com/caddyserver/dist
 Source1:        https://raw.githubusercontent.com/caddyserver/dist/master/config/Caddyfile
 Source2:        https://raw.githubusercontent.com/caddyserver/dist/master/init/caddy.service
+Source7:        https://raw.githubusercontent.com/caddyserver/dist/master/init/caddy-defaults
 Source3:        https://raw.githubusercontent.com/caddyserver/dist/master/init/caddy-api.service
 Source4:        https://raw.githubusercontent.com/caddyserver/dist/master/welcome/index.html
 Source5:        https://raw.githubusercontent.com/caddyserver/dist/master/scripts/completions/bash-completion
@@ -77,6 +78,9 @@ install -D -p -m 0755 caddy %{buildroot}%{_bindir}/caddy
 
 # config
 install -D -p -m 0644 %{S:1} %{buildroot}%{_sysconfdir}/caddy/Caddyfile
+
+# /etc/defaults/caddy for the caddy.service:
+install -D -p -m 0644 %{S:7} %{buildroot}%{_sysconfdir}/default/caddy
 
 # systemd units
 install -D -p -m 0644 %{S:2} %{buildroot}%{_unitdir}/caddy.service
@@ -142,6 +146,7 @@ if [ $1 -eq 0 ]; then
         semanage fcontext --delete --type httpd_exec_t        '%{_bindir}/caddy'               2> /dev/null || :
         semanage fcontext --delete --type httpd_sys_content_t '%{_datadir}/caddy(/.*)?'        2> /dev/null || :
         semanage fcontext --delete --type httpd_config_t      '%{_sysconfdir}/caddy(/.*)?'     2> /dev/null || :
+        semanage fcontext --delete --type httpd_config_t      '%{_sysconfdir}/default/caddy'     2> /dev/null || :
         semanage fcontext --delete --type httpd_var_lib_t     '%{_sharedstatedir}/caddy(/.*)?' 2> /dev/null || :
         # QUIC
         semanage port     --delete --type http_port_t --proto udp 80   2> /dev/null || :


### PR DESCRIPTION
This is a "simple" method to not mess with the systemd services file but to allow the sysadmin to use the /etc/default/caddy to point to a different (especially .json) config file and EXTRA_PARAMS support for --resume (or --watch etc.) 

I know there is a "new recommended" method to make use of `systemctl edit` as mentioned [here](https://serverfault.com/questions/413397/how-to-set-environment-variable-in-systemd-service) but that is not what I'm "ised" to, and the /etc/default/caddy is easier to ansible `lineinfile` edit