### PR TITLE
deb: Create `/var/log/caddy` directory on install

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -18,6 +18,12 @@ if [ "$1" = "configure" ]; then
 	if getent group www-data >/dev/null; then
 		usermod -aG www-data caddy
 	fi
+
+	# Add log directory with correct permissions
+	if [ ! -d /var/log/caddy ]; then
+		mkdir -p /var/log/caddy
+		chown -R caddy:caddy /var/log/caddy
+	fi
 fi
 
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then


### PR DESCRIPTION
Something I realized we probably should have done earlier. This'll just create the directory if it doesn't exist and set the permissions, next time people update (i.e. to v2.4.0). Should let us tell people to just put their logs in there.

Is the ownership `caddy:caddy` correct here? Tagging @carlwgeorge since you have more experience with conventions for this type of stuff. Should it be more like `root:caddy`? I'm not sure what's most conventional.