### PR TITLE
config: Use a block for the default Caddyfile

### DIFF
--- a/config/Caddyfile
+++ b/config/Caddyfile
@@ -5,21 +5,22 @@
 #
 # To use your own domain name (with automatic HTTPS), first make
 # sure your domain's A/AAAA DNS records are properly pointed to
-# this machine's public IP, then replace the line below with your
+# this machine's public IP, then replace ":80" below with your
 # domain name.
-:80
 
-# Set this path to your site's directory.
-root * /usr/share/caddy
+:80 {
+	# Set this path to your site's directory.
+	root * /usr/share/caddy
 
-# Enable the static file server.
-file_server
+	# Enable the static file server.
+	file_server
 
-# Another common task is to set up a reverse proxy:
-# reverse_proxy localhost:8080
+	# Another common task is to set up a reverse proxy:
+	# reverse_proxy localhost:8080
 
-# Or serve a PHP site through php-fpm:
-# php_fastcgi localhost:9000
+	# Or serve a PHP site through php-fpm:
+	# php_fastcgi localhost:9000
+}
 
 # Refer to the Caddy docs for more information:
 # https://caddyserver.com/docs/caddyfile


### PR DESCRIPTION
Over the past year or so of giving support on the forums https://caddy.community, I've noticed that plenty of users tend to get confused with the the layout of the config because of the optional nature of the site blocks `{ }` braces, which are only optional if you're serving a single site.

I think using a block by default up-front should help clarify for new users what's going on and avoid the problem of adding sites which then get incorrectly parsed as directives.

Some example threads:

- https://caddy.community/t/caddy-doesnt-seem-to-start-run-or-do-secure-connections/12140
- https://caddy.community/t/how-to-set-up-caddy-to-work-with-a-web-app-build-with-django-run-with-docker-compose/12028
- https://caddy.community/t/caddy-pihole-wireguard/11669
- https://caddy.community/t/cant-run-caddy-after-apt-install-that-did-not-seem-to-have-errors/11309
- https://caddy.community/t/totally-new-to-this/10910
- https://caddy.community/t/multiple-path-redirects-only-one-works/10871
- https://caddy.community/t/unrecognized-directive/9545
- etc.