### PR TITLE
doc: bump the copyright year at welcome page

### DIFF
--- a/welcome/index.html
+++ b/welcome/index.html
@@ -258,7 +258,7 @@
 		</div>
 
 		<footer>
-			&copy; Copyright 2019 The Caddy Authors.
+			&copy; Copyright 2021 The Caddy Authors.
 			<br>
 			Caddy<sup>&reg;</sup> is a registered trademark of Light Code Labs, LLC.
 

--- a/welcome/index.html
+++ b/welcome/index.html
@@ -258,12 +258,15 @@
 		</div>
 
 		<footer>
-			&copy; Copyright 2021 The Caddy Authors.
+			&copy; Copyright <span id="current_year">2021</span> The Caddy Authors.
 			<br>
 			Caddy<sup>&reg;</sup> is a registered trademark of Light Code Labs, LLC.
 
 			<div id="disclaimer">The Caddy project is not responsible for the content, disposition, or behavior of this Web property, which is independently owned and maintained. For inquiries, please contact the site owner or hosting provider.</div>
 		</footer>
 
+		<script>
+			document.getElementById("current_year").textContent = new Date().getFullYear();
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
It looks/feels so old if 2019 is still written there.

That said, of course you could also write 2019-2021 to show the initial development year (of the HTML page? Or of caddy, however?).
IT's not really clear what the copyright year refers to, but an old year just is psychologically – not good…