### PR TITLE
systemd: Add `PrivateDevices`

### DIFF
--- a/init/caddy.service
+++ b/init/caddy.service
@@ -28,6 +28,7 @@ ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
 TimeoutStopSec=5s
 LimitNOFILE=1048576
 LimitNPROC=512
+PrivateDevices=yes
 PrivateTmp=true
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE


### PR DESCRIPTION
`caddy.service` hardening options are uneven between distributions:

```ini
[Service]
LimitNOFILE=1048576            # ArchLinux, Fedora, OpenSUSE
LimitNPROC=512                 # ArchLinux, Fedora, OpenSUSE
LockPersonality=yes            # since systemd 235, in ArchLinux
MemoryDenyWriteExecute=yes     # since systemd 231, in ArchLinux
NoNewPrivileges=yes            # since systemd 239, in ArchLinux, NixOS
PrivateDevices=yes             # since systemd 209, in ArchLinux, NixOS, OpenSUSE
PrivateTmp=yes                 # ArchLinux, Fedora, OpenSUSE
ProcSubset=pid                 # since systemd 247, in ArchLinux
ProtectClock=yes               # since systemd 245, in ArchLinux, OpenSUSE
ProtectControlGroups=yes       # since systemd 232, in ArchLinux, OpenSUSE
ProtectHome=yes                # since systemd 214, in ArchLinux, NixOS, Fedora, OpenSUSE
ProtectHostname=yes            # since systemd 242, in ArchLinux, OpenSUSE
ProtectKernelLogs=yes          # since systemd 244, in ArchLinux, OpenSUSE
ProtectKernelModules=yes       # since systemd 232, in ArchLinux, OpenSUSE
ProtectKernelTunables=yes      # since systemd 232, in ArchLinux, OpenSUSE
ProtectProc=invisible          # since systemd 247, in ArchLinux
RemoveIPC=yes                  # since systemd 232, in ArchLinux
RestrictNamespaces=yes         # since systemd 233, in ArchLinux
RestrictRealtime=yes           # since systemd 231, in ArchLinux, OpenSUSE
RestrictSUIDSGID=yes           # since systemd 242, in ArchLinux
TimeoutStopSec=5s              # since systemd 188, in ArchLinux, Fedora, OpenSUSE
```

Sources:

  * https://archlinux.org/packages/community/x86_64/caddy/
  * https://packages.fedoraproject.org/pkgs/caddy/
  * https://software.opensuse.org/package/caddy

This pull request proposes to upstream these options.

Thanks,