### PR TITLE
Fix horizontal overflow on welcome-page

### DIFF
--- a/welcome/index.html
+++ b/welcome/index.html
@@ -16,6 +16,7 @@
 				background: #f1f4f5;
 				font-family: sans-serif;
 				font-size: 20px;
+				overflow-x: hidden;
 				-webkit-font-smoothing: antialiased;
 			}
 


### PR DESCRIPTION
This is a tiny css fix to prevent the page from overflowing on the x-axis. This currently happens e.g. on firefox on ubuntu

_Cheers!_

Note: I made a typo in  the commit message and wrote "vertical" instead of "horizontal" - sorry!