### PR TITLE
set working directory at `/etc/caddy` when service is launched

### DIFF
--- a/init/caddy.service
+++ b/init/caddy.service
@@ -23,6 +23,7 @@ Requires=network-online.target
 Type=notify
 User=caddy
 Group=caddy
+WorkingDirectory=/etc/caddy
 ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
 ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --force
 TimeoutStopSec=5s


### PR DESCRIPTION
## Description

I can't currently paste logs  but it says that no sites-enabled directory or file was found.

### Steps to reproduce

 put this in `/etc/caddy/Caddyfile` : `import sites-enabled/*`
`cd <elsewhere_than_/etc/caddy>`
`systemctl start caddy.service`

### Expected result

Should import files of directory

### Actual result

Fails.

### Solution proposed

To patch it, I simply did `systemctl edit caddy.service` and then input this : 
```
[Service]
WorkingDirectory=/etc/caddy
```