### PR TITLE
init: enable systemd DynamicUser support

### DIFF
--- a/init/README.md
+++ b/init/README.md
@@ -12,9 +12,11 @@ See our website for [installation instructions](https://caddyserver.com/docs/ins
 
 ## Prerequisites
 
-Running Caddy as a systemd service requires the following:
+Caddy runs best on modern Linux distributions with
+[systemd](https://systemd.io).
 
-
+<details>
+  <summary>If you are using an older distribution release such as CentOS 7, see these instructions for the extra prerequisites</summary>
 Group named `caddy`:
 
 ```bash
@@ -32,7 +34,7 @@ $ useradd --system \
     --comment "Caddy web server" \
     caddy
 ```
-
+</details>
 
 ## Choosing a service file
 

--- a/init/caddy-api.service
+++ b/init/caddy-api.service
@@ -25,5 +25,13 @@ PrivateTmp=true
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
+# systemd dynamic user support, remove this if you use an ancient distro
+DynamicUser=yes
+DynamicGroup=yes
+StateDirectory=caddy
+LogsDirectory=caddy
+CacheDirectory=caddy
+Environment=HOME=/var/lib/private/caddy
+
 [Install]
 WantedBy=multi-user.target

--- a/init/caddy.service
+++ b/init/caddy.service
@@ -32,5 +32,13 @@ PrivateTmp=true
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 
+# systemd dynamic user support, remove this if you use an ancient distro
+DynamicUser=yes
+DynamicGroup=yes
+StateDirectory=caddy
+LogsDirectory=caddy
+CacheDirectory=caddy
+Environment=HOME=/var/lib/private/caddy
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows people to set up Caddy on a machine without having to create a dedicated user or group. The user and group will be dynamically allocated by systemd. See [1] or [2] for more information.

[1]: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=
[2]: https://0pointer.net/blog/dynamic-users-with-systemd.html