### PR TITLE
Auto restart caddy if it crashes under systemd

### DIFF
--- a/init/caddy-api.service
+++ b/init/caddy-api.service
@@ -24,6 +24,8 @@ LimitNPROC=512
 PrivateTmp=true
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/init/caddy.service
+++ b/init/caddy.service
@@ -31,6 +31,8 @@ LimitNPROC=512
 PrivateTmp=true
 ProtectSystem=full
 AmbientCapabilities=CAP_NET_BIND_SERVICE
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Alas caddy does crash occasionally and the current systemd service
file does not auto restart it which causes an outage.

This adds auto restart to the two caddy service files.
