### PR TITLE
feat: create runtimedirectory on start

### DIFF
--- a/init/caddy.service
+++ b/init/caddy.service
@@ -23,6 +23,7 @@ Requires=network-online.target
 Type=notify
 User=caddy
 Group=caddy
+RuntimeDirectory=caddy
 ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/Caddyfile
 ExecReload=/usr/bin/caddy reload --config /etc/caddy/Caddyfile --force
 TimeoutStopSec=5s


### PR DESCRIPTION
Caddy supports listening on a unix socket. To make it easier for users to manage said socket (including permissions), let systemd handle the creation of it.