### PR TITLE
deb: remove user and its files on purge

### DIFF
--- a/scripts/postremove.sh
+++ b/scripts/postremove.sh
@@ -19,4 +19,8 @@ if [ "$1" = "purge" ]; then
 		deb-systemd-helper unmask caddy.service >/dev/null || true
 		deb-systemd-helper unmask caddy-api.service >/dev/null || true
 	fi
+	# 'purge' is not supposed to leave package files behind,
+	# so remove the user along with other dirs.
+	userdel -r caddy || true
+	rm -rf /var/lib/caddy /var/log/caddy /etc/caddy
 fi


### PR DESCRIPTION
I've come acorss [a patch](https://salsa.debian.org/go-team/packages/caddy/-/commit/6fee99c8387aee6fafea0c354e045bac8334211c) in Debian packaging of Caddy which I thought is useful. I took a different approach which I believe is cleaner.

@francislavoie, there's [another patch](https://salsa.debian.org/go-team/packages/caddy/-/commit/ffc2d77a55be9db2e4abc61941f3d860f0939731) that I've found but not sure what's the point behind it. Any insight?